### PR TITLE
Set the variable VIRTUAL_ENV_DISABLE_PROMPT to True.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ For Mac users, I highly recommend iTerm 2 + Solarized Dark
 * Dirty working directory (±, color change)
 * Working directory
 * Elevated (root) privileges (⚡)
+* Current virtualenv (Python)  
+You will probably want to disable the default virtualenv prompt. Add to your [`init.fish`](https://github.com/oh-my-fish/oh-my-fish#dotfiles):  
+`set --export VIRTUAL_ENV_DISABLE_PROMPT 1`
 
 
 Ported from https://gist.github.com/agnoster/3712874.

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -91,6 +91,7 @@ end
 
 function prompt_virtual_env -d "Display Python virtual environment"
   if test "$VIRTUAL_ENV"
+    set --universal --export VIRTUAL_ENV_DISABLE_PROMPT 'True'
     prompt_segment white black (basename $VIRTUAL_ENV)
   end
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -91,7 +91,6 @@ end
 
 function prompt_virtual_env -d "Display Python virtual environment"
   if test "$VIRTUAL_ENV"
-    set --universal --export VIRTUAL_ENV_DISABLE_PROMPT 'True'
     prompt_segment white black (basename $VIRTUAL_ENV)
   end
 end


### PR DESCRIPTION
When activating a Python virtualenv, the activate code checks if this variable is set. If it empty, it will modify the prompt. Agnoster has this built in, so we set the variable to True to disable.
#10 has the initial issue.
