### PR TITLE
Remove `available` function

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -213,10 +213,6 @@ function prompt_status -d "the symbols for a non zero exit status, root and back
     end
 end
 
-function available -a name -d "Check if a function or program is available."
-  type "$name" ^/dev/null >&2
-end
-
 # ===========================
 # Apply theme
 # ===========================


### PR DESCRIPTION
This removes the `available` function from the `right_prompt.fish` as it was wrongly included in my last pull-request.
It's already available in the base of OMF.
