### PR TITLE
Use git status --porcelain

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -28,7 +28,7 @@ set -g __fish_git_prompt_char_cleanstate ''
 function parse_git_dirty
   set -l submodule_syntax
   set submodule_syntax "--ignore-submodules=dirty"
-  set git_dirty (command git status -s $submodule_syntax  2> /dev/null)
+  set git_dirty (command git status --porcelain $submodule_syntax  2> /dev/null)
   if [ -n "$git_dirty" ]
     if [ $__fish_git_prompt_showdirtystate = "yes" ]
       echo -n "$__fish_git_prompt_char_dirtystate"


### PR DESCRIPTION
This fixes #15 
As noted by @ProLoser in #15:
We should use `git status --porcelain` instead of
`git status -s`. This change should be more future proof according to the
git man page.
