### PR TITLE
fix mode indicator for fish v2.3

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -52,10 +52,11 @@ function prompt_vi_mode -d 'vi mode status indicator'
 end
 
 function fish_right_prompt -d 'Prints right prompt'
+  if test "$fish_key_bindings" = "fish_vi_key_bindings"
     set -l first_color black
     set_color $first_color
     echo "$right_segment_separator"
-    right_prompt_segment $first_color
     prompt_vi_mode
     end_right_prompt
+  end
 end

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -52,11 +52,10 @@ function prompt_vi_mode -d 'vi mode status indicator'
 end
 
 function fish_right_prompt -d 'Prints right prompt'
-  if set -q __fish_vi_mode
     set -l first_color black
     set_color $first_color
     echo "$right_segment_separator"
+    right_prompt_segment $first_color
     prompt_vi_mode
     end_right_prompt
-  end
 end


### PR DESCRIPTION
This fixes the mode indicator by 
- removing the `set -q __fish_vi_mode` check as this doesn't work anymore in v2.3. I have yet to find a new way to this, @sn0cr do you happen to know one?
- restoring the `right_prompt_segment $first_color` line. This was removed in a follow up commit to my last pull request and breaks the coloring of the left-facing arrow.
