### PR TITLE
Simplify and fix right prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A fish theme optimized for people who use:
 * Mercurial (requires 'hg prompt')
 * SVN
 * Unicode-compatible fonts and terminals (I use iTerm2 + Menlo)
+* Fish Vi-mode
 
 For Mac users, I highly recommend iTerm 2 + Solarized Dark
 
@@ -26,7 +27,6 @@ For Mac users, I highly recommend iTerm 2 + Solarized Dark
 * Current virtualenv (Python)
 You will probably want to disable the default virtualenv prompt. Add to your [`init.fish`](https://github.com/oh-my-fish/oh-my-fish#dotfiles):
 `set --export VIRTUAL_ENV_DISABLE_PROMPT 1`
-* Indicate vi mode. (If you've set `fish_vi_mode` in your config and don't like the ugly left prompt indicator you can solve this by replacing it with `set -g fish_key_bindings fish_vi_key_bindings` and then removing the `if set -q __fish_vi_mode` check at the bottom of the `fish_right_prompt.fish`)
-
+* Indicate vi mode.
 
 Ported from https://gist.github.com/agnoster/3712874.

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -10,6 +10,7 @@
 ## Set this options in your config.fish (if you want to :])
 # set -g theme_display_user yes
 # set -g theme_hide_hostname yes
+# set -g theme_hide_hostname no
 # set -g default_user your_normal_user
 
 
@@ -117,7 +118,7 @@ end
 
 function get_hostname -d "Set current hostname to prompt variable $HOSTNAME_PROMPT if connected via SSH"
   set -g HOSTNAME_PROMPT ""
-  if [ "$theme_hide_hostname" != "yes" -a -n "$SSH_CLIENT" ]
+  if [ "$theme_hide_hostname" = "no" -o \( "$theme_hide_hostname" != "yes" -a -n "$SSH_CLIENT" \) ]
     set -g HOSTNAME_PROMPT (hostname)
   end
 end

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -1,62 +1,34 @@
 # right prompt for agnoster theme
 # shows vim mode status
 
-set right_segment_separator \uE0B2
-set -g agnoster_right_current_bg NONE
-function right_prompt_segment -d "Function to draw a right segment"
-  set -l bg
-  set -l fg
-  if [ -n "$argv[1]" ]
-    set bg $argv[1]
-  else
-    set bg normal
-  end
-  if [ -n "$argv[2]" ]
-    set fg $argv[2]
-  else
-    set fg normal
-  end
-  if [ "$agnoster_right_current_bg" != 'NONE' -a "$argv[1]" != "$agnoster_right_current_bg" ]
-    set_color -b $agnoster_right_current_bg
-    set_color $bg
-    echo -n " $right_segment_separator"
-    set_color -b $bg
-    set_color $fg
-  else
-    set_color -b $bg
-    set_color $fg
-  end
-  set agnoster_right_current_bg $argv[1]
-  if [ -n "$argv[3]" ]
-    echo -n -s " " $argv[3]
-  end
-end
-
-function end_right_prompt
-  if [ -n $agnoster_right_current_bg ]
-        set_color -b normal
-        set_color $agnoster_right_current_bg
-  end
-  set -g agnoster_right_current_bg NONE
+# Redefine fish_mode_prompt function as empty to hide fish-shell mode indicator
+function fish_mode_prompt
 end
 
 function prompt_vi_mode -d 'vi mode status indicator'
+  set -l right_segment_separator \uE0B2
   switch $fish_bind_mode
       case default
-        right_prompt_segment green black "N"
+        set_color green
+        echo "$right_segment_separator"
+        set_color -b green black
+        echo " N "
       case insert
-        right_prompt_segment blue black "I"
+        set_color blue
+        echo "$right_segment_separator"
+        set_color -b blue black
+        echo " I "
       case visual
-        right_prompt_segment red black "V"
+        set_color red
+        echo "$right_segment_separator"
+        set_color -b red black
+        echo " V "
     end
 end
 
 function fish_right_prompt -d 'Prints right prompt'
-  if set -q __fish_vi_mode
-    set -l first_color black
-    set_color $first_color
-    echo "$right_segment_separator"
+  if test "$fish_key_bindings" = "fish_vi_key_bindings"
     prompt_vi_mode
-    end_right_prompt
+    set_color normal
   end
 end


### PR DESCRIPTION
The right prompt shows a Vi mode indicator.
This commit rewrites it with native fish-shell functions, fixes the coloring
issue seen before and adds a new check for the vi mode used from fish v2.3
onward so it is only shown when vi mode is enabled.

This is the follow up pull request as discussed in #19 
