### PR TITLE
using 'svn info' to detect svn repo for faster prompt

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -171,7 +171,7 @@ end
 
 function prompt_svn -d "Display the current svn state"
   set -l ref
-  if command svn ls . >/dev/null 2>&1
+  if command svn info >/dev/null 2>&1
     set branch (svn_get_branch)
     set branch_symbol \uE0A0
     set revision (svn_get_revision)


### PR DESCRIPTION
'svn ls' takes about 2.6 sec on my pc. 'svn info' takes about 0.033 sec. 'svn ls' fetches info from central repo according to 'svn help ls' command. As a result, it is getting slowed for online repositories. 'svn info' performs better in this regard.