### PR TITLE
Reset color to normal after final segment separator

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -113,9 +113,10 @@ end
 
 function prompt_finish -d "Close open segments"
   if [ -n $current_bg ]
-    set_color -b normal
+    set_color normal
     set_color $current_bg
     echo -n "$segment_separator "
+    set_color normal
   end
   set -g current_bg NONE
 end


### PR DESCRIPTION
Currently, the final foreground color in the prompt sticks around for the beginning of what the user types next. Usually, fish will try to suggest an autocomplete option (accompanied by a color change), so this isn't obvious. This will manifest if fish doesn't change the color right away, such as when the user types a valid one-letter command. I personally noticed this because I have an abbreviation `g=git` set; notice the green 'g' that matches the end of the prompt in the following image.

![image](https://user-images.githubusercontent.com/2991842/45791500-e716ae00-bc57-11e8-9fed-3648442dede8.png)

This PR fixes this issue by reseting the colors after `echo`ing the last segment separator in `prompt_finish`. The bug and this PR's fix are demonstrated below by `echo`ing a string after manually printing the prompt.

before | after
---|---
![image](https://user-images.githubusercontent.com/2991842/45791123-36f47580-bc56-11e8-8c69-3a4e3c2d8410.png) | ![image](https://user-images.githubusercontent.com/2991842/45791164-76bb5d00-bc56-11e8-9eb5-2883fa8767ca.png)