### PR TITLE
add blacklist for source control in directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ For Mac users, I highly recommend iTerm 2 + Solarized Dark
 You will probably want to disable the default virtualenv prompt. Add to your [`init.fish`](https://github.com/oh-my-fish/oh-my-fish#dotfiles):
 `set --export VIRTUAL_ENV_DISABLE_PROMPT 1`
 * Indicate vi mode.
+* Source control blacklist. To disable source control prompts in certain directories, you can add the following to your `init.fish` or `config.fish`: `set -g scm_prompt_blacklist "/path/to/blacklist"`.
 
 Ported from https://gist.github.com/agnoster/3712874.

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -18,6 +18,7 @@
 set -g current_bg NONE
 set segment_separator \uE0B0
 set right_segment_separator \uE0B0
+set -q scm_prompt_blacklist; or set scm_prompt_blacklist
 
 # ===========================
 # Color setting
@@ -74,6 +75,11 @@ function parse_git_dirty
   end
 end
 
+function cwd_in_scm_blacklist
+  for entry in $scm_prompt_blacklist
+    pwd | grep $entry -
+  end
+end
 
 # ===========================
 # Segments functions
@@ -263,8 +269,10 @@ function fish_prompt
   prompt_virtual_env
   prompt_user
   prompt_dir
-  type -q hg;  and prompt_hg
-  type -q git; and prompt_git
-  type -q svn; and prompt_svn
+  if [ (cwd_in_scm_blacklist | wc -c) -eq 0 ]
+    type -q hg;  and prompt_hg
+    type -q git; and prompt_git
+    type -q svn; and prompt_svn
+  end
   prompt_finish
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -77,7 +77,7 @@ end
 
 function cwd_in_scm_blacklist
   for entry in $scm_prompt_blacklist
-    pwd | grep $entry -
+    pwd | grep "^$entry" -
   end
 end
 


### PR DESCRIPTION
This is either an alternative or or an addition to #35 .

I got tired of blanket disabling source control prompts since my issue only showed up in a specific directory. This PR adds the ability to specify a blacklist of directories. If the current working directory matches any of the directories in the blacklist, then the source control prompt will not be displayed.