### PR TITLE
Only run dirty state computation if we should show the dirty state

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -61,16 +61,14 @@ set -g __fish_git_prompt_char_dirtystate '±'
 set -g __fish_git_prompt_char_cleanstate ''
 
 function parse_git_dirty
-  set -l submodule_syntax
-  set submodule_syntax "--ignore-submodules=dirty"
-  set git_dirty (command git status --porcelain $submodule_syntax  2> /dev/null)
-  if [ -n "$git_dirty" ]
-    if [ $__fish_git_prompt_showdirtystate = "yes" ]
-      echo -n "$__fish_git_prompt_char_dirtystate"
-    end
-  else
-    if [ $__fish_git_prompt_showdirtystate = "yes" ]
-      echo -n "$__fish_git_prompt_char_cleanstate"
+  if [ $__fish_git_prompt_showdirtystate = "yes" ]
+    set -l submodule_syntax
+    set submodule_syntax "--ignore-submodules=dirty"
+    set git_dirty (command git status --porcelain $submodule_syntax  2> /dev/null)
+    if [ -n "$git_dirty" ]
+        echo -n "$__fish_git_prompt_char_dirtystate"
+    else
+        echo -n "$__fish_git_prompt_char_cleanstate"
     end
   end
 end


### PR DESCRIPTION
I have a pretty large repository, and the command to show dirty state was basically making fish unusable in that repository. I fixed this locally by only doing the dirty state computation *if* we were actually going to use it. Otherwise this should just be a no-op function.