### PR TITLE
Add config option to ignore untracked git files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ For Mac users, I highly recommend iTerm 2 + Solarized Dark
 * Branch () or detached head (➦)
 * Current branch / SHA1 in detached head state
 * Dirty working directory (±, color change)
+  * By default, git repos will show as dirty if there are untracked files. This can be changed by adding `set -g set -g fish_git_prompt_untracked_files no` to your `config.fish`. This value is passed into `git status --untracked-files`, so any value git supports is valid for this command
 * Working directory
 * Elevated (root) privileges (⚡)
 * Current virtualenv (Python)

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -51,6 +51,12 @@ set -q color_status_superuser_str; or set color_status_superuser_str yellow
 set -q color_status_jobs_bg; or set color_status_jobs_bg black
 set -q color_status_jobs_str; or set color_status_jobs_str cyan
 
+# ===========================
+# Git settings
+# set -g color_dir_bg red
+
+set -q fish_git_prompt_untracked_files; or set fish_git_prompt_untracked_files normal
+
 
 # ===========================
 # Helper methods
@@ -64,7 +70,8 @@ function parse_git_dirty
   if [ $__fish_git_prompt_showdirtystate = "yes" ]
     set -l submodule_syntax
     set submodule_syntax "--ignore-submodules=dirty"
-    set git_dirty (command git status --porcelain $submodule_syntax  2> /dev/null)
+    set untracked_syntax "--untracked-files=$fish_git_prompt_untracked_files"
+    set git_dirty (command git status --porcelain $submodule_syntax $untracked_syntax 2> /dev/null)
     if [ -n "$git_dirty" ]
         echo -n "$__fish_git_prompt_char_dirtystate"
     else


### PR DESCRIPTION
The `parse_git_dirty` function currently does a git status which includes all untracked files. Not only doe some repos have a lot of auto generated files, but in large code bases doing a git status without filtering untracked files can take a long time. This change adds an option so it is possible to change the behavior of the command.