### PR TITLE
use `uname -n` instead of `hostname`

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -175,7 +175,7 @@ end
 function get_hostname -d "Set current hostname to prompt variable $HOSTNAME_PROMPT if connected via SSH"
   set -g HOSTNAME_PROMPT ""
   if [ "$theme_hide_hostname" = "no" -o \( "$theme_hide_hostname" != "yes" -a -n "$SSH_CLIENT" \) ]
-    set -g HOSTNAME_PROMPT (hostname)
+    set -g HOSTNAME_PROMPT (uname -n)
   end
 end
 


### PR DESCRIPTION
Some Linux distributions (e.g. Arch Linux) do not have `hostname` command by default, which is used by `get_hostname` function.

This PR changes `hostname` to `uname -n`.
Tested in Ubuntu, Arch Linux and macOS.

We do not use `$hostname` variable which was introduced in fish 3.0 in order to keep backward compatibility.