### PR TITLE
Disable Subversion by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ For Mac users, I highly recommend iTerm 2 + Solarized Dark
 * If the previous command failed (✘)
 - If private mode is enabled (🔒)
 * User @ Hostname (if user is not DEFAULT_USER, which can be set in your profile)
-* Git/HG/SVN status
+* Git/HG status
+* Subversion status enabled by adding `set -g theme_svn_prompt_enabled yes` to your `config.fish`.
 * Branch () or detached head (➦)
 * Current branch / SHA1 in detached head state
 * Dirty working directory (±, color change)

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -12,6 +12,7 @@
 # set -g theme_hide_hostname yes
 # set -g theme_hide_hostname no
 # set -g default_user your_normal_user
+# set -g theme_svn_prompt_enabled yes
 
 
 
@@ -59,6 +60,10 @@ set -q color_status_private_str; or set color_status_private_str purple
 
 set -q fish_git_prompt_untracked_files; or set fish_git_prompt_untracked_files normal
 
+# ===========================
+# Subversion settings
+
+set -q theme_svn_prompt_enabled; or set theme_svn_prompt_enabled no
 
 # ===========================
 # Helper methods
@@ -298,7 +303,9 @@ function fish_prompt
   if [ (cwd_in_scm_blacklist | wc -c) -eq 0 ]
     type -q hg;  and prompt_hg
     type -q git; and prompt_git
-    type -q svn; and prompt_svn
+    if [ "$theme_svn_prompt_enabled" = "yes" ]
+      type -q svn; and prompt_svn
+    end
   end
   prompt_finish
 end


### PR DESCRIPTION
This mirrors a choice made in upstream fish (as of version 3.1.2).

/usr/bin/svn on macOS is now a stub and is very slow by default causing significant delays in the fish prompt coming up. Given Subversion is not a particularly wide-spread VCS these days and given the upstream choice to disable it, this disables Subversion in the prompt by default but allows it to be easily re-enabled.