### PR TITLE
fish_prompt: Set theme variables globally

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -17,9 +17,9 @@
 
 
 set -g current_bg NONE
-set segment_separator \uE0B0
-set right_segment_separator \uE0B0
-set -q scm_prompt_blacklist; or set scm_prompt_blacklist
+set -g segment_separator \uE0B0
+set -g right_segment_separator \uE0B0
+set -q scm_prompt_blacklist; or set -g scm_prompt_blacklist
 
 # ===========================
 # Color setting
@@ -29,41 +29,41 @@ set -q scm_prompt_blacklist; or set scm_prompt_blacklist
 # If not set, default color from agnoster will be used.
 # ===========================
 
-set -q color_virtual_env_bg; or set color_virtual_env_bg white
-set -q color_virtual_env_str; or set color_virtual_env_str black
-set -q color_user_bg; or set color_user_bg black
-set -q color_user_str; or set color_user_str yellow
-set -q color_dir_bg; or set color_dir_bg blue
-set -q color_dir_str; or set color_dir_str black
-set -q color_hg_changed_bg; or set color_hg_changed_bg yellow
-set -q color_hg_changed_str; or set color_hg_changed_str black
-set -q color_hg_bg; or set color_hg_bg green
-set -q color_hg_str; or set color_hg_str black
-set -q color_git_dirty_bg; or set color_git_dirty_bg yellow
-set -q color_git_dirty_str; or set color_git_dirty_str black
-set -q color_git_bg; or set color_git_bg green
-set -q color_git_str; or set color_git_str black
-set -q color_svn_bg; or set color_svn_bg green
-set -q color_svn_str; or set color_svn_str black
-set -q color_status_nonzero_bg; or set color_status_nonzero_bg black
-set -q color_status_nonzero_str; or set color_status_nonzero_str red
-set -q color_status_superuser_bg; or set color_status_superuser_bg black
-set -q color_status_superuser_str; or set color_status_superuser_str yellow
-set -q color_status_jobs_bg; or set color_status_jobs_bg black
-set -q color_status_jobs_str; or set color_status_jobs_str cyan
-set -q color_status_private_bg; or set color_status_private_bg black
-set -q color_status_private_str; or set color_status_private_str purple
+set -q color_virtual_env_bg; or set -g color_virtual_env_bg white
+set -q color_virtual_env_str; or set -g color_virtual_env_str black
+set -q color_user_bg; or set -g color_user_bg black
+set -q color_user_str; or set -g color_user_str yellow
+set -q color_dir_bg; or set -g color_dir_bg blue
+set -q color_dir_str; or set -g color_dir_str black
+set -q color_hg_changed_bg; or set -g color_hg_changed_bg yellow
+set -q color_hg_changed_str; or set -g color_hg_changed_str black
+set -q color_hg_bg; or set -g color_hg_bg green
+set -q color_hg_str; or set -g color_hg_str black
+set -q color_git_dirty_bg; or set -g color_git_dirty_bg yellow
+set -q color_git_dirty_str; or set -g color_git_dirty_str black
+set -q color_git_bg; or set -g color_git_bg green
+set -q color_git_str; or set -g color_git_str black
+set -q color_svn_bg; or set -g color_svn_bg green
+set -q color_svn_str; or set -g color_svn_str black
+set -q color_status_nonzero_bg; or set -g color_status_nonzero_bg black
+set -q color_status_nonzero_str; or set -g color_status_nonzero_str red
+set -q color_status_superuser_bg; or set -g color_status_superuser_bg black
+set -q color_status_superuser_str; or set -g color_status_superuser_str yellow
+set -q color_status_jobs_bg; or set -g color_status_jobs_bg black
+set -q color_status_jobs_str; or set -g color_status_jobs_str cyan
+set -q color_status_private_bg; or set -g color_status_private_bg black
+set -q color_status_private_str; or set -g color_status_private_str purple
 
 # ===========================
 # Git settings
 # set -g color_dir_bg red
 
-set -q fish_git_prompt_untracked_files; or set fish_git_prompt_untracked_files normal
+set -q fish_git_prompt_untracked_files; or set -g fish_git_prompt_untracked_files normal
 
 # ===========================
 # Subversion settings
 
-set -q theme_svn_prompt_enabled; or set theme_svn_prompt_enabled no
+set -q theme_svn_prompt_enabled; or set -g theme_svn_prompt_enabled no
 
 # ===========================
 # Helper methods


### PR DESCRIPTION
This allows Agnoster to be wrapped by other scripts. For example, kitty started wrapping `fish_prompt` [shortly after version 0.23.1][1]. In such cases, local variables get declared in the scope of the wrapping agent and therefore are unavailable in the prompt scope.

[1]: https://github.com/kovidgoyal/kitty/commit/23f94b6e6729f262343b1cd2bebd2f433d4a3f7c

Ref.: oh-my-fish/oh-my-fish#861