### PR TITLE
Moved the virtualenv prompt

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -327,9 +327,9 @@ end
 function fish_prompt
   set -g RETVAL $status
   prompt_status
-  prompt_virtual_env
   prompt_user
   prompt_dir
+  prompt_virtual_env
   if [ (cwd_in_scm_blacklist | wc -c) -eq 0 ]
     type -q hg;  and prompt_hg
     type -q git; and prompt_git


### PR DESCRIPTION
The virtual env prompt now comes after the user and directory prompts. This creates a much nicer looking prompt, without splitting the status segment from the user one.

Should resolve #66