### PR TITLE
Don't show system packages in `nix shell` prompt

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -194,17 +194,20 @@ function prompt_virtual_env -d "Display Python or Nix virtual environment"
   # available in PATH, so it is useful to print them all.
   set nix_packages
   for p in $PATH
+    # nix shell prepends store paths contiguously to PATH
+    # so everything after the first non-/nix/store is the system environment
     set package_name_version (string match --regex '/nix/store/\w+-([^/]+)/.*' $p)[2]
-    if test "$package_name_version"
-      set package_name (string match --regex '^(.*)-(\d+(\.\d)+|unstable-20\d{2}-\d{2}-\d{2})' $package_name_version)[2]
-      if test "$try_to_trim_nix_package_version" = "yes" -a -n "$package_name"
-        set package $package_name
-      else
-        set package $package_name_version
-      end
-      if not contains $package $nix_packages
-        set nix_packages $nix_packages $package
-      end
+    if not test "$package_name_version"
+      break
+    end
+    set package_name (string match --regex '^(.*)-(\d+(\.\d)+|unstable-20\d{2}-\d{2}-\d{2})' $package_name_version)[2]
+    if test "$try_to_trim_nix_package_version" = "yes" -a -n "$package_name"
+      set package $package_name
+    else
+      set package $package_name_version
+    end
+    if not contains $package $nix_packages
+      set nix_packages $nix_packages $package
     end
   end
   if test (count $nix_packages) -gt $max_package_count_visible_in_prompt


### PR DESCRIPTION
Hello friends.

My env prompt has been polluted with system packages that agnoster mistakenly thinks belong to `nix shell`

<img width="1776" height="111" alt="image" src="https://github.com/user-attachments/assets/a88dfcb0-906c-47e9-b027-0b18ebdd7337" />

This PR stops processing `/nix/store` paths after the first non-nix path in `PATH`. `nix shell` prepends to `PATH`, before entries like `/run/wrappers/bin`, `/usr/local/bin`, etc. so it *should* work consistently.

Tested on NixOS. It should work on non-NixOS systems with just nix but I haven't validated it.

Addresses #74